### PR TITLE
add easy way to clean regularly unused cached dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,47 @@
 npm-cache
 =========
-this npm-cache is a fork of npm-cache from dashlane that supports arg flowthrough and creates more robust hashes to avoid using wrong hash  tar - only the npm version is targeted in this instance...your mileage may vary with the other packagers.
-Hash is created by globbing devdependencies, dependencies and installOptions.
-
-this can also be used to create environment specific hash tarballs (on a build server)
-
-for instance
-`npm-cache install npm --production --bserver01`
-would create a different hash tarball than
-`npm-cache install npm --production --bserver02`
+this npm-cache is a fork of npm-cache from swarajban
 
 `npm-cache` is a command line utility that caches dependencies installed via `npm`, `bower`, `jspm`, `composer` and `yarn`.
 
 It is useful for build processes that run `[npm|bower|composer|jspm|yarn] install` every time as part of their 
 build process. Since dependencies don't change often, this often means slower build times. `npm-cache`
 helps alleviate this problem by caching previously installed dependencies on the build machine. 
-`npm-cache` can be a drop-in replacement for any build script that runs `[npm|bower|composer|jspm] install`. 
-
-In order to speed up even more the build process, a --useSymlink option has been added: when first installing the
-dependencies, it copy them without archiving them, and on a subsequent build, it just create a symbolic link in 
-your project to point to the cached dependencies. Doing so, "npm install" actually takes less than 1 sec.
+`npm-cache` can be a drop-in replacement for any build script that runs `[npm|bower|composer|jspm|yarn] install`. 
 
 ## How it Works
 When you run `npm-cache install [npm|bower|jspm|composer|yarn]`, it first looks for `package.json`, `bower.json`,
-or `composer.json` in the current working directory depending on which dependency manager is requested.
+`composer.json`, `yarn.lock`, etc. in the current working directory depending on which dependency manager is requested.
 It then calculates the MD5 hash of the configuration file and looks for a filed named 
 <MD5 of config.json>.tar.gz in the cache directory ($HOME/.package_cache by default). If the file does not
 exist, `npm-cache` uses the system's installed dependency manager to install the dependencies. Once the
 dependencies are installed, `npm-cache` tars the newly downloaded dependencies and stores them in the 
 cache directory. The next time `npm-cache` runs and sees the same config file, it will find the tarball
 in the cache directory and untar the dependencies in the current working directory.
+
+## Advanced features
+
+### No archive
+When storing the newly dependencies installed, npm-cache can perform a simple copy from the current project
+to the cache directory instead of creating a tar.gz
+
+### symbolic link
+Used with the no archive feature, this feature provide the fastest npm install possible. When the dependencies
+have already been cached, it just creates a symbolic link from the current directory to the cached dependencies.
+For big project, copying all the dependencies from the cached folder, or unTARing the TARed dependencies can be 
+time consuming
+
+A reverse symbolic link can be created from the cached dependency folder to the current folder to mimic exactly
+the configuration of a normal npm install
+
+### Args flowthrough
+Curtesy of Klaus Hougesen, npm-cache supports arg flowthrough and takes args into account when calculating hashes
+Hash is created by globbing devdependencies, dependencies and installOptions. This can also be used to create 
+environment specific hash tarballs on a build server.
+For instance
+`npm-cache install npm --production --bserver01`
+would create a different hash tarball than
+`npm-cache install npm --production --bserver02`
 
 
 ## Installation
@@ -54,6 +66,7 @@ npm-cache install bower --allow-root composer --dry-run
    npm-cache install    # try to install npm, bower, and composer components
    npm-cache install bower  # install only bower components
    npm-cache install bower npm  # install bower and npm components
+   npm-cache install --cleanOldCachedDepsSince 3 npm  # clean cached dependency not used since 3 days and then install npm components
    npm-cache install --cacheDirectory /home/cache/ bower    # install components using /home/cache as cache directory
    npm-cache install --forceRefresh  bower  # force installing dependencies from package manager without cache
    npm-cache install --noArchive npm    # do not compress/archive the cached dependencies
@@ -61,17 +74,9 @@ npm-cache install bower --allow-root composer --dry-run
    npm-cache install npm --production -msvs_version=2013    # add args to npm installer
    npm-cache install npm --production -msvs_version=2013 bower --silent # add args to npm installer and bower
    npm-cache clean  # cleans out all cached files in cache directory
+   npm-cache clean --cleanOldCachedDepsSince 3 # cleans cached files in cache directory that are older than 3 days
    npm-cache hash   # reports the current working hash
 ```
 
 ## Contributing
-Though I have a busy day job, I will do my best to add simple feature requests and
-merge PRs as soon as I can. I know this package is not following many of today's best
-practices (namely TESTS, a proper branching strategy, and more), but I hope you still
-find it useful.
-
-**Important**: Please submit all pull requests to the branch [feature/pull-requests](https://github.com/swarajban/npm-cache/tree/feature/pull-requests)
-
-
-
-[![Analytics](https://ga-beacon.appspot.com/UA-8932221-3/swarajban/npm-cache)](https://github.com/swarajban/npm-cache)
+Feel free to contribute and to submit PRs @ https://github.com/Dashlane/npm-cache

--- a/cacheDependencyManagers/cacheDependencyManager.js
+++ b/cacheDependencyManagers/cacheDependencyManager.js
@@ -202,6 +202,9 @@ CacheDependencyManager.prototype.installCachedDependencies = function (cachePath
   this.cacheLogInfo('...cleared');
   this.cacheLogInfo('retrieving dependencies from ' + cachePath + ' to ' + targetPath);
 
+  //update last modified date of cachePath to know we used that archive
+  fs.utimesSync(cachePath, Date.now()/1000, Date.now()/1000);
+
   function onError(error) {
     self.cacheLogError('Error retrieving ' + cachePath + ': ' + error);
     callback(error);


### PR DESCRIPTION
2 things in this PR:
 - clean of the readme file which was getting out of control
 - super usefull feature to avoid cached dependencies to indefinitely fill your HD

On our servers, we use npm-cache, and we run into space issue, or we have issues with the number of file on the HD (yes this is true!). Hence, we have to regularly clean the cache by running npm-cache clean.

With this PR, you can say "please clean automatically everything not used since more than 7 days".